### PR TITLE
[WIP] very unoptimized and rough implementation of wrangler.Apply tracing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	sigs.k8s.io/cli-utils v0.37.2
 )
 
-replace github.com/rancher/lasso => github.com/alexandreLamarre/lasso v0.0.0-20250220164910-86ea5a76fc72
+replace github.com/rancher/lasso => github.com/alexandreLamarre/lasso v0.0.0-20250220182050-3d3f249800e7
 
 require (
 	cel.dev/expr v0.18.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,8 @@ require (
 	sigs.k8s.io/cli-utils v0.37.2
 )
 
+replace github.com/rancher/lasso => github.com/alexandreLamarre/lasso v0.0.0-20250220164910-86ea5a76fc72
+
 require (
 	cel.dev/expr v0.18.0 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.0 // indirect
@@ -96,6 +98,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiserver v0.32.1 // indirect
 	k8s.io/component-base v0.32.1 // indirect
+	k8s.io/klog v1.0.0 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -10,8 +10,11 @@ require (
 	github.com/moby/locker v1.0.1
 	github.com/pkg/errors v0.9.1
 	github.com/rancher/lasso v0.2.1
+	github.com/samber/lo v1.49.1
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.10.0
+	go.opentelemetry.io/otel v1.28.0
+	go.opentelemetry.io/otel/trace v1.28.0
 	go.uber.org/mock v0.5.0
 	golang.org/x/sync v0.11.0
 	golang.org/x/text v0.22.0
@@ -71,12 +74,10 @@ require (
 	github.com/stoewer/go-strcase v1.3.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.53.0 // indirect
-	go.opentelemetry.io/otel v1.28.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.28.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.27.0 // indirect
 	go.opentelemetry.io/otel/metric v1.28.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.28.0 // indirect
-	go.opentelemetry.io/otel/trace v1.28.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.3.1 // indirect
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 // indirect
 	golang.org/x/mod v0.23.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 cel.dev/expr v0.18.0 h1:CJ6drgk+Hf96lkLikr4rFf19WrU0BOWEihyZnI2TAzo=
 cel.dev/expr v0.18.0/go.mod h1:MrpN08Q+lEBs+bGYdLxxHkZoUSsCp0nSKTs0nTymJgw=
+github.com/alexandreLamarre/lasso v0.0.0-20250220164910-86ea5a76fc72 h1:EUYDe6P3riu+S9S2rCPausXd7mr2SHK3/Q9yHJTBXG8=
+github.com/alexandreLamarre/lasso v0.0.0-20250220164910-86ea5a76fc72/go.mod h1:hP/cdkLE/jjzg9EBPVyFwOP1pfWVdL2eFxY+LNCYGVE=
 github.com/antlr4-go/antlr/v4 v4.13.0 h1:lxCg3LAv+EUK6t1i0y1V6/SLeUi0eKEKdhQAlS8TVTI=
 github.com/antlr4-go/antlr/v4 v4.13.0/go.mod h1:pfChB/xh/Unjila75QW7+VU4TSnWnnk9UTnmpPaOR2g=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a h1:idn718Q4B6AGu/h5Sxe66HYVdqdGu2l9Iebqhi/AEoA=
@@ -31,6 +33,7 @@ github.com/fxamacker/cbor/v2 v2.7.0 h1:iM5WgngdRBanHcxugY4JySA0nk1wZorNOpTgCMedv
 github.com/fxamacker/cbor/v2 v2.7.0/go.mod h1:pxXPTn3joSm21Gbwsv0w9OSA2y1HFR9qXEeXQVeNoDQ=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
 github.com/go-logr/logr v0.2.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=
@@ -118,8 +121,6 @@ github.com/prometheus/common v0.55.0 h1:KEi6DK7lXW/m7Ig5i47x0vRzuBsHuvJdi5ee6Y3G
 github.com/prometheus/common v0.55.0/go.mod h1:2SECS4xJG1kd8XF9IcM1gMX6510RAEL65zxzNImwdc8=
 github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0learggepc=
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
-github.com/rancher/lasso v0.2.1 h1:SZTqMVQn8cAOqvwGBd1/EYOIJ/MGN+UfJrOWvHd4jHU=
-github.com/rancher/lasso v0.2.1/go.mod h1:KSV3jBXfdXqdCuMm2uC8kKB9q/wuDYb3h0eHZoRjShM=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
@@ -266,6 +267,8 @@ k8s.io/gengo v0.0.0-20250130153323-76c5745d3511 h1:4eL6zr5VCj71nu2nOuQ6j6m/kqh5W
 k8s.io/gengo v0.0.0-20250130153323-76c5745d3511/go.mod h1:FiNAH4ZV3gBg2Kwh89tzAEV2be7d5xI0vBa/VySYy3E=
 k8s.io/gengo/v2 v2.0.0-20240911193312-2b36238f13e9 h1:si3PfKm8dDYxgfbeA6orqrtLkvvIeH8UqffFJDl0bz4=
 k8s.io/gengo/v2 v2.0.0-20240911193312-2b36238f13e9/go.mod h1:EJykeLsmFC60UQbYJezXkEsG2FLrt0GPNkU5iK5GWxU=
+k8s.io/klog v1.0.0 h1:Pt+yjF5aB1xDSVbau4VsWe+dQNzA0qv1LlXdC2dF6Q8=
+k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 k8s.io/klog/v2 v2.2.0/go.mod h1:Od+F08eJP+W3HUb4pSrPpgp9DGU4GzlpG/TmITuYh/Y=
 k8s.io/klog/v2 v2.130.1 h1:n9Xl7H1Xvksem4KFG4PYbdQCQxqc/tTUyrgXaOhHSzk=
 k8s.io/klog/v2 v2.130.1/go.mod h1:3Jpz1GvMt720eyJH1ckRHK1EDfpxISzJ7I9OYgaDtPE=

--- a/go.sum
+++ b/go.sum
@@ -123,6 +123,8 @@ github.com/rancher/lasso v0.2.1/go.mod h1:KSV3jBXfdXqdCuMm2uC8kKB9q/wuDYb3h0eHZo
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/samber/lo v1.49.1 h1:4BIFyVfuQSEpluc7Fua+j1NolZHiEHEpaSEKdsH0tew=
+github.com/samber/lo v1.49.1/go.mod h1:dO6KHFzUKXgP8LDhU0oI8d2hekjXnGOu0DB8Jecxd6o=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/spf13/cobra v1.8.1 h1:e5/vxKd/rZsfSJMUX1agtjeTDf+qv1/JdBF8gg5k9ZM=

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 cel.dev/expr v0.18.0 h1:CJ6drgk+Hf96lkLikr4rFf19WrU0BOWEihyZnI2TAzo=
 cel.dev/expr v0.18.0/go.mod h1:MrpN08Q+lEBs+bGYdLxxHkZoUSsCp0nSKTs0nTymJgw=
-github.com/alexandreLamarre/lasso v0.0.0-20250220164910-86ea5a76fc72 h1:EUYDe6P3riu+S9S2rCPausXd7mr2SHK3/Q9yHJTBXG8=
-github.com/alexandreLamarre/lasso v0.0.0-20250220164910-86ea5a76fc72/go.mod h1:hP/cdkLE/jjzg9EBPVyFwOP1pfWVdL2eFxY+LNCYGVE=
+github.com/alexandreLamarre/lasso v0.0.0-20250220182050-3d3f249800e7 h1:R9Zu1IlTziuO4aFQg2LnJtOIZOukTk9p6hmazlAFuy0=
+github.com/alexandreLamarre/lasso v0.0.0-20250220182050-3d3f249800e7/go.mod h1:hP/cdkLE/jjzg9EBPVyFwOP1pfWVdL2eFxY+LNCYGVE=
 github.com/antlr4-go/antlr/v4 v4.13.0 h1:lxCg3LAv+EUK6t1i0y1V6/SLeUi0eKEKdhQAlS8TVTI=
 github.com/antlr4-go/antlr/v4 v4.13.0/go.mod h1:pfChB/xh/Unjila75QW7+VU4TSnWnnk9UTnmpPaOR2g=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a h1:idn718Q4B6AGu/h5Sxe66HYVdqdGu2l9Iebqhi/AEoA=

--- a/pkg/apply/apply.go
+++ b/pkg/apply/apply.go
@@ -20,7 +20,7 @@ const (
 	defaultNamespace = "default"
 )
 
-type Patcher func(namespace, name string, pt types.PatchType, data []byte) (runtime.Object, error)
+type Patcher func(ctx context.Context, namespace, name string, pt types.PatchType, data []byte) (runtime.Object, error)
 
 // Reconciler return false if it did not handle this object
 type Reconciler func(oldObj runtime.Object, newObj runtime.Object) (bool, error)

--- a/pkg/apply/desiredset_apply.go
+++ b/pkg/apply/desiredset_apply.go
@@ -7,7 +7,11 @@ import (
 	"sync"
 	"time"
 
+	"github.com/samber/lo"
 	"github.com/sirupsen/logrus"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 
 	gvk2 "github.com/rancher/wrangler/v3/pkg/gvk"
 
@@ -31,6 +35,10 @@ const (
 	LabelHash      = "objectset.rio.cattle.io/hash"
 	LabelPrefix    = "objectset.rio.cattle.io/"
 	LabelPrune     = "objectset.rio.cattle.io/prune"
+)
+
+var (
+	applyTracer = otel.GetTracerProvider().Tracer("github.com/rancher/wrangler/v3/pkg/apply")
 )
 
 var (
@@ -63,6 +71,35 @@ func (o *desiredSet) getRateLimit(labelHash string) flowcontrol.RateLimiter {
 	return rl
 }
 
+func (o *desiredSet) attrs() []attribute.KeyValue {
+	return []attribute.KeyValue{
+		attribute.String("setID", o.setID),
+		attribute.String("owner", fmt.Sprintf("%T", o.owner)),
+		attribute.Bool("remove", o.remove),
+		attribute.Bool("noDelete", o.noDelete),
+		attribute.Bool("createPlan", o.createPlan),
+		attribute.Bool("setOwnerReference", o.setOwnerReference),
+		attribute.Bool("ownerReferenceController", o.ownerReferenceController),
+		attribute.Bool("ownerReferenceBlock", o.ownerReferenceBlock),
+		attribute.Bool("strictCaching", o.strictCaching),
+		attribute.Bool("restrictClusterScoped", o.restrictClusterScoped),
+		attribute.Float64("ratelimitingQps", float64(o.ratelimitingQps)),
+		attribute.StringSlice("injectorNames", o.injectorNames),
+		attribute.StringSlice("pruneTypes", lo.Map(lo.Keys(o.pruneTypes), func(gvk schema.GroupVersionKind, _ int) string {
+			return gvk.String()
+		})),
+		attribute.StringSlice("patchers", lo.Map(lo.Keys(o.patchers), func(gvk schema.GroupVersionKind, _ int) string {
+			return gvk.String()
+		})),
+		attribute.StringSlice("reconcilers", lo.Map(lo.Keys(o.reconcilers), func(gvk schema.GroupVersionKind, _ int) string {
+			return gvk.String()
+		})),
+		attribute.StringSlice("noDeleteGVK", lo.Map(lo.Keys(o.reconcilers), func(gvk schema.GroupVersionKind, _ int) string {
+			return gvk.String()
+		})),
+	}
+}
+
 func (o *desiredSet) dryRun() (Plan, error) {
 	o.createPlan = true
 	o.plan.Create = objectset.ObjectKeyByGVK{}
@@ -73,16 +110,22 @@ func (o *desiredSet) dryRun() (Plan, error) {
 }
 
 func (o *desiredSet) apply() error {
+	spanCtx, span := applyTracer.Start(o.ctx, "apply")
+	defer span.End()
+
 	if o.objs == nil || o.objs.Len() == 0 {
 		o.remove = true
 	}
+	span.SetAttributes(o.attrs()...)
 
 	if err := o.Err(); err != nil {
+		span.SetStatus(codes.Error, err.Error())
 		return err
 	}
-
+	span.AddEvent("GetLabelsAndAnnotations")
 	labelSet, annotationSet, err := GetLabelsAndAnnotations(o.setID, o.owner)
 	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
 		return o.err(err)
 	}
 
@@ -94,30 +137,42 @@ func (o *desiredSet) apply() error {
 			logrus.Infof("rate limited %s(%s) %s", o.setID, labelSet, d)
 		}
 	}
-
+	span.AddEvent("injectLabelsAndAnnotations")
 	objList, err := o.injectLabelsAndAnnotations(labelSet, annotationSet)
 	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
 		return o.err(err)
 	}
-
+	span.AddEvent("runInjectors")
 	objList, err = o.runInjectors(objList)
 	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
 		return o.err(err)
 	}
 
+	span.AddEvent("collect")
 	objs := o.collect(objList)
 
 	debugID := o.debugID()
+	span.SetAttributes(attribute.String("debugID", debugID))
+	span.AddEvent("GetSelector")
 	sel, err := GetSelector(labelSet)
 	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
 		return o.err(err)
 	}
 
 	for _, gvk := range o.objs.GVKOrder(o.knownGVK()...) {
-		o.process(debugID, sel, gvk, objs[gvk])
+		span.AddEvent(fmt.Sprintf("process : %s", gvk.String()))
+		o.process(spanCtx, debugID, sel, gvk, objs[gvk])
 	}
 
-	return o.Err()
+	if err := o.Err(); err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		return err
+	}
+	span.SetStatus(codes.Ok, "success")
+	return nil
 }
 
 func (o *desiredSet) knownGVK() (ret []schema.GroupVersionKind) {

--- a/pkg/apply/desiredset_compare.go
+++ b/pkg/apply/desiredset_compare.go
@@ -3,6 +3,7 @@ package apply
 import (
 	"bytes"
 	"compress/gzip"
+	"context"
 	"encoding/base64"
 	"io/ioutil"
 	"strings"
@@ -172,7 +173,7 @@ func sanitizePatch(patch []byte, removeObjectSetAnnotation bool) ([]byte, error)
 	return json.Marshal(data)
 }
 
-func applyPatch(gvk schema.GroupVersionKind, reconciler Reconciler, patcher Patcher, debugID string, ignoreOriginal bool, oldObject, newObject runtime.Object, diffPatches [][]byte) (bool, error) {
+func applyPatch(ctx context.Context, gvk schema.GroupVersionKind, reconciler Reconciler, patcher Patcher, debugID string, ignoreOriginal bool, oldObject, newObject runtime.Object, diffPatches [][]byte) (bool, error) {
 	oldMetadata, err := meta.Accessor(oldObject)
 	if err != nil {
 		return false, err
@@ -233,12 +234,12 @@ func applyPatch(gvk schema.GroupVersionKind, reconciler Reconciler, patcher Patc
 	}
 
 	logrus.Debugf("DesiredSet - Updated %s %s/%s for %s -- %s %s", gvk, oldMetadata.GetNamespace(), oldMetadata.GetName(), debugID, patchType, patch)
-	_, err = patcher(oldMetadata.GetNamespace(), oldMetadata.GetName(), patchType, patch)
+	_, err = patcher(ctx, oldMetadata.GetNamespace(), oldMetadata.GetName(), patchType, patch)
 
 	return true, err
 }
 
-func (o *desiredSet) compareObjects(span trace.Span, gvk schema.GroupVersionKind, reconciler Reconciler, patcher Patcher, client dynamic.NamespaceableResourceInterface, debugID string, oldObject, newObject runtime.Object, force bool) error {
+func (o *desiredSet) compareObjects(ctx context.Context, span trace.Span, gvk schema.GroupVersionKind, reconciler Reconciler, patcher Patcher, client dynamic.NamespaceableResourceInterface, debugID string, oldObject, newObject runtime.Object, force bool) error {
 	oldMetadata, err := meta.Accessor(oldObject)
 	if err != nil {
 		return err
@@ -263,7 +264,7 @@ func (o *desiredSet) compareObjects(span trace.Span, gvk schema.GroupVersionKind
 		return string(b)
 	})))
 
-	if ran, err := applyPatch(gvk, reconciler, patcher, debugID, o.ignorePreviousApplied, oldObject, newObject, diffPatches); err != nil {
+	if ran, err := applyPatch(ctx, gvk, reconciler, patcher, debugID, o.ignorePreviousApplied, oldObject, newObject, diffPatches); err != nil {
 		return err
 	} else if !ran {
 		span.SetAttributes(attribute.Bool("noChange", true))

--- a/pkg/apply/desiredset_compare.go
+++ b/pkg/apply/desiredset_compare.go
@@ -13,7 +13,10 @@ import (
 	"github.com/rancher/wrangler/v3/pkg/data/convert"
 	"github.com/rancher/wrangler/v3/pkg/objectset"
 	patch2 "github.com/rancher/wrangler/v3/pkg/patch"
+	"github.com/samber/lo"
 	"github.com/sirupsen/logrus"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 	"k8s.io/apimachinery/pkg/api/meta"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -235,7 +238,7 @@ func applyPatch(gvk schema.GroupVersionKind, reconciler Reconciler, patcher Patc
 	return true, err
 }
 
-func (o *desiredSet) compareObjects(gvk schema.GroupVersionKind, reconciler Reconciler, patcher Patcher, client dynamic.NamespaceableResourceInterface, debugID string, oldObject, newObject runtime.Object, force bool) error {
+func (o *desiredSet) compareObjects(span trace.Span, gvk schema.GroupVersionKind, reconciler Reconciler, patcher Patcher, client dynamic.NamespaceableResourceInterface, debugID string, oldObject, newObject runtime.Object, force bool) error {
 	oldMetadata, err := meta.Accessor(oldObject)
 	if err != nil {
 		return err
@@ -256,12 +259,16 @@ func (o *desiredSet) compareObjects(gvk schema.GroupVersionKind, reconciler Reco
 		GroupVersionKind: gvk,
 	}]...)
 
+	span.SetAttributes(attribute.StringSlice("diffPatches", lo.Map(diffPatches, func(b []byte, _ int) string {
+		return string(b)
+	})))
+
 	if ran, err := applyPatch(gvk, reconciler, patcher, debugID, o.ignorePreviousApplied, oldObject, newObject, diffPatches); err != nil {
 		return err
 	} else if !ran {
+		span.SetAttributes(attribute.Bool("noChange", true))
 		logrus.Debugf("DesiredSet - No change(2) %s %s/%s for %s", gvk, oldMetadata.GetNamespace(), oldMetadata.GetName(), debugID)
 	}
-
 	return nil
 }
 

--- a/pkg/apply/desiredset_crud.go
+++ b/pkg/apply/desiredset_crud.go
@@ -2,6 +2,7 @@ package apply
 
 import (
 	"bytes"
+	"context"
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -52,7 +53,7 @@ func (o *desiredSet) get(nsed bool, namespace, name string, client dynamic.Names
 	return client.Get(o.ctx, name, v1.GetOptions{})
 }
 
-func (o *desiredSet) delete(nsed bool, namespace, name string, client dynamic.NamespaceableResourceInterface, force bool, gvk schema.GroupVersionKind) error {
+func (o *desiredSet) delete(ctx context.Context, nsed bool, namespace, name string, client dynamic.NamespaceableResourceInterface, force bool, gvk schema.GroupVersionKind) error {
 	if !force {
 		if o.noDelete {
 			return nil
@@ -65,8 +66,8 @@ func (o *desiredSet) delete(nsed bool, namespace, name string, client dynamic.Na
 		PropagationPolicy: &deletePolicy,
 	}
 	if nsed {
-		return client.Namespace(namespace).Delete(o.ctx, name, opts)
+		return client.Namespace(namespace).Delete(ctx, name, opts)
 	}
 
-	return client.Delete(o.ctx, name, opts)
+	return client.Delete(ctx, name, opts)
 }

--- a/pkg/apply/desiredset_crud.go
+++ b/pkg/apply/desiredset_crud.go
@@ -34,7 +34,7 @@ func (o *desiredSet) toUnstructured(obj runtime.Object) (*unstructured.Unstructu
 	return unstruct, json.Unmarshal(buf.Bytes(), &unstruct.Object)
 }
 
-func (o *desiredSet) create(nsed bool, namespace string, client dynamic.NamespaceableResourceInterface, obj runtime.Object) (runtime.Object, error) {
+func (o *desiredSet) create(ctx context.Context, nsed bool, namespace string, client dynamic.NamespaceableResourceInterface, obj runtime.Object) (runtime.Object, error) {
 	unstr, err := o.toUnstructured(obj)
 	if err != nil {
 		return nil, err
@@ -43,7 +43,7 @@ func (o *desiredSet) create(nsed bool, namespace string, client dynamic.Namespac
 	if nsed {
 		return client.Namespace(namespace).Create(o.ctx, unstr, v1.CreateOptions{})
 	}
-	return client.Create(o.ctx, unstr, v1.CreateOptions{})
+	return client.Create(ctx, unstr, v1.CreateOptions{})
 }
 
 func (o *desiredSet) get(nsed bool, namespace, name string, client dynamic.NamespaceableResourceInterface) (runtime.Object, error) {

--- a/pkg/apply/desiredset_process.go
+++ b/pkg/apply/desiredset_process.go
@@ -11,6 +11,8 @@ import (
 	"github.com/rancher/wrangler/v3/pkg/merr"
 	"github.com/rancher/wrangler/v3/pkg/objectset"
 	"github.com/sirupsen/logrus"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 	"golang.org/x/sync/errgroup"
 	errors2 "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -207,7 +209,13 @@ func (o *desiredSet) filterCrossVersion(gvk schema.GroupVersionKind, keys []obje
 	return result
 }
 
-func (o *desiredSet) process(debugID string, set labels.Selector, gvk schema.GroupVersionKind, objs objectset.ObjectByKey) {
+func (o *desiredSet) process(ctx context.Context, debugID string, set labels.Selector, gvk schema.GroupVersionKind, objs objectset.ObjectByKey) {
+	spanCtx, span := applyTracer.Start(ctx, fmt.Sprintf("process/%s", debugID))
+	defer span.End()
+	span.SetAttributes(
+		attribute.String("GVK", gvk.String()),
+		attribute.String("LabelSelector", set.String()),
+	)
 	controller, client, err := o.getControllerAndClient(debugID, gvk)
 	if err != nil {
 		o.err(err)
@@ -282,14 +290,27 @@ func (o *desiredSet) process(debugID string, set labels.Selector, gvk schema.Gro
 		toDelete = nil
 	}
 
-	createF := func(k objectset.ObjectKey) {
+	createF := func(ctx context.Context, k objectset.ObjectKey) {
+		// TODO : create span
+		_, createSpan := applyTracer.Start(ctx, fmt.Sprintf("Create %s/%s", k.Namespace, k.Name))
+		defer createSpan.End()
+		createSpan.SetAttributes(
+			attribute.String("namespace", k.Namespace),
+			attribute.String("name", k.Name),
+		)
 		obj := objs[k]
+		createSpan.SetAttributes(
+			attribute.String("object", fmt.Sprintf("%T", obj)),
+		)
+		span.AddEvent("prepareObjectForCreate")
 		obj, err := prepareObjectForCreate(gvk, obj)
 		if err != nil {
-			o.err(errors.Wrapf(err, "failed to prepare create %s %s for %s", k, gvk, debugID))
+			err := errors.Wrapf(err, "failed to prepare create %s %s for %s", k, gvk, debugID)
+			createSpan.SetStatus(codes.Error, err.Error())
+			o.err(err)
 			return
 		}
-
+		span.AddEvent("create")
 		_, err = o.create(nsed, k.Namespace, client, obj)
 		if errors2.IsAlreadyExists(err) {
 			// Taking over an object that wasn't previously managed by us
@@ -301,40 +322,66 @@ func (o *desiredSet) process(debugID string, set labels.Selector, gvk schema.Gro
 			}
 		}
 		if err != nil {
-			o.err(errors.Wrapf(err, "failed to create %s %s for %s", k, gvk, debugID))
+			err := errors.Wrapf(err, "failed to create %s %s for %s", k, gvk, debugID)
+			o.err(err)
+			createSpan.SetStatus(codes.Error, err.Error())
 			return
 		}
 		logrus.Debugf("DesiredSet - Created %s %s for %s", gvk, k, debugID)
+		createSpan.SetStatus(codes.Ok, "created")
 	}
 
-	deleteF := func(k objectset.ObjectKey, force bool) {
-		if err := o.delete(nsed, k.Namespace, k.Name, client, force, gvk); err != nil {
-			o.err(errors.Wrapf(err, "failed to delete %s %s for %s", k, gvk, debugID))
+	deleteF := func(ctx context.Context, k objectset.ObjectKey, force bool) {
+		spanCtx, deleteSpan := applyTracer.Start(ctx, fmt.Sprintf("Delete %s/%s", k.Namespace, k.Name))
+		defer span.End()
+		deleteSpan.SetAttributes(
+			attribute.String("namespace", k.Namespace),
+			attribute.String("name", k.Name),
+			attribute.Bool("force", force),
+		)
+		if err := o.delete(spanCtx, nsed, k.Namespace, k.Name, client, force, gvk); err != nil {
+			err := errors.Wrapf(err, "failed to delete %s %s for %s", k, gvk, debugID)
+			o.err(err)
+			deleteSpan.SetStatus(codes.Error, err.Error())
 			return
 		}
 		logrus.Debugf("DesiredSet - Delete %s %s for %s", gvk, k, debugID)
+		deleteSpan.SetStatus(codes.Ok, "deleted")
 	}
 
-	updateF := func(k objectset.ObjectKey) {
-		err := o.compareObjects(gvk, reconciler, patcher, client, debugID, existing[k], objs[k], len(toCreate) > 0 || len(toDelete) > 0)
+	updateF := func(ctx context.Context, k objectset.ObjectKey) {
+		spanCtx, updateSpan := applyTracer.Start(ctx, fmt.Sprintf("Update %s/%s", k.Namespace, k.Name))
+		defer updateSpan.End()
+		updateSpan.SetAttributes(
+			attribute.String("namespace", k.Namespace),
+			attribute.String("name", k.Name),
+		)
+		err := o.compareObjects(updateSpan, gvk, reconciler, patcher, client, debugID, existing[k], objs[k], len(toCreate) > 0 || len(toDelete) > 0)
 		if err == ErrReplace {
-			deleteF(k, true)
-			o.err(fmt.Errorf("DesiredSet - Replace Wait %s %s for %s", gvk, k, debugID))
+			deleteF(spanCtx, k, true)
+			err := fmt.Errorf("DesiredSet - Replace Wait %s %s for %s", gvk, k, debugID)
+			o.err(err)
+			updateSpan.SetStatus(codes.Error, err.Error())
+			return
 		} else if err != nil {
-			o.err(errors.Wrapf(err, "failed to update %s %s for %s", k, gvk, debugID))
+			err := errors.Wrapf(err, "failed to update %s %s for %s", k, gvk, debugID)
+			o.err(err)
+			updateSpan.SetStatus(codes.Error, err.Error())
+			return
 		}
+		updateSpan.SetStatus(codes.Ok, "updated")
 	}
 
 	for _, k := range toCreate {
-		createF(k)
+		createF(spanCtx, k)
 	}
 
 	for _, k := range toUpdate {
-		updateF(k)
+		updateF(spanCtx, k)
 	}
 
 	for _, k := range toDelete {
-		deleteF(k, false)
+		deleteF(spanCtx, k, false)
 	}
 }
 

--- a/pkg/apply/desiredset_process.go
+++ b/pkg/apply/desiredset_process.go
@@ -186,11 +186,11 @@ func (o *desiredSet) clearNamespace(objs objectset.ObjectByKey) error {
 }
 
 func (o *desiredSet) createPatcher(client dynamic.NamespaceableResourceInterface) Patcher {
-	return func(namespace, name string, pt types2.PatchType, data []byte) (object runtime.Object, e error) {
+	return func(ctx context.Context, namespace, name string, pt types2.PatchType, data []byte) (object runtime.Object, e error) {
 		if namespace != "" {
-			return client.Namespace(namespace).Patch(o.ctx, name, pt, data, v1.PatchOptions{})
+			return client.Namespace(namespace).Patch(ctx, name, pt, data, v1.PatchOptions{})
 		}
-		return client.Patch(o.ctx, name, pt, data, v1.PatchOptions{})
+		return client.Patch(ctx, name, pt, data, v1.PatchOptions{})
 	}
 }
 
@@ -275,7 +275,7 @@ func (o *desiredSet) process(ctx context.Context, debugID string, set labels.Sel
 		o.plan.Delete[gvk] = toDelete
 
 		reconciler = nil
-		patcher = func(namespace, name string, pt types2.PatchType, data []byte) (runtime.Object, error) {
+		patcher = func(ctx context.Context, namespace, name string, pt types2.PatchType, data []byte) (runtime.Object, error) {
 			data, err := sanitizePatch(data, true)
 			if err != nil {
 				return nil, err
@@ -291,8 +291,7 @@ func (o *desiredSet) process(ctx context.Context, debugID string, set labels.Sel
 	}
 
 	createF := func(ctx context.Context, k objectset.ObjectKey) {
-		// TODO : create span
-		_, createSpan := applyTracer.Start(ctx, fmt.Sprintf("Create %s/%s", k.Namespace, k.Name))
+		spanCtx, createSpan := applyTracer.Start(ctx, fmt.Sprintf("Create %s/%s", k.Namespace, k.Name))
 		defer createSpan.End()
 		createSpan.SetAttributes(
 			attribute.String("namespace", k.Namespace),
@@ -311,7 +310,7 @@ func (o *desiredSet) process(ctx context.Context, debugID string, set labels.Sel
 			return
 		}
 		span.AddEvent("create")
-		_, err = o.create(nsed, k.Namespace, client, obj)
+		_, err = o.create(spanCtx, nsed, k.Namespace, client, obj)
 		if errors2.IsAlreadyExists(err) {
 			// Taking over an object that wasn't previously managed by us
 			existingObj, err := o.get(nsed, k.Namespace, k.Name, client)
@@ -356,7 +355,7 @@ func (o *desiredSet) process(ctx context.Context, debugID string, set labels.Sel
 			attribute.String("namespace", k.Namespace),
 			attribute.String("name", k.Name),
 		)
-		err := o.compareObjects(updateSpan, gvk, reconciler, patcher, client, debugID, existing[k], objs[k], len(toCreate) > 0 || len(toDelete) > 0)
+		err := o.compareObjects(spanCtx, updateSpan, gvk, reconciler, patcher, client, debugID, existing[k], objs[k], len(toCreate) > 0 || len(toDelete) > 0)
 		if err == ErrReplace {
 			deleteF(spanCtx, k, true)
 			err := fmt.Errorf("DesiredSet - Replace Wait %s %s for %s", gvk, k, debugID)


### PR DESCRIPTION
A real implementation would likely have the tracing/span logic in a separate go file with 
```go
go:build tracing
```

and a another file for the no-op functions that I would ensure get stripped by compiler optimizations, with:
```go
go:build !tracing
```

---

The current overhead with default batch settings is between 20% - 70% extra CPU time, which is definitely not production ready even for a debug build, working on seeing if it's feasible to get it down to 20% as an upper bound.


Like in Kubernetes, potential debug builds might have to use exponential sampling. We could also pass in context.Context values to force creating a child span for consumers of the tracing "sdk" for specific code paths that have a high potential of bugs, say for specific downstream debug builds (prometheus-federator)
